### PR TITLE
refactor: Add auth hoc for token and current path verification

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,20 +6,27 @@ import SignUp from './pages/SignUp';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import GlobalStyle from './GlobalStyle';
 import { AccessTokenContext } from '@/context/TokenContext';
+import withAuth from './hocs/withAuth';
 
 function App() {
   const jwt = localStorage.getItem('token');
   const [token, setToken] = useState(jwt);
 
+  // 각 페이지 컴포넌트에 withAuth HOC를 적용하여 인증 여부를 체크
+  const HomeWithAuth = withAuth(Home);
+  const SignInWithAuth = withAuth(SignIn);
+  const SignUpWithAuth = withAuth(SignUp);
+  const TodoWithAuth = withAuth(Todo);
+
   return (
-    <AccessTokenContext.Provider value={{token, setToken}}>
+    <AccessTokenContext.Provider value={{ token, setToken }}>
       <BrowserRouter basename={process.env.PUBLIC_URL}>
-      <GlobalStyle />
+        <GlobalStyle />
         <Routes>
-          <Route path='/' element={<Home />}/>
-          <Route path='/signin' element={<SignIn />}/>
-          <Route path='/signup' element={<SignUp />}/>
-          <Route path='/todo' element={<Todo />}/>
+          <Route path='/' element={<HomeWithAuth />} />
+          <Route path='/signin' element={<SignInWithAuth />} />
+          <Route path='/signup' element={<SignUpWithAuth />} />
+          <Route path='/todo' element={<TodoWithAuth />} />
         </Routes>
       </BrowserRouter>
     </AccessTokenContext.Provider>

--- a/src/hocs/withAuth.jsx
+++ b/src/hocs/withAuth.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+// 사용자의 토큰 정보를 가져와 로그인한 사용자만 접근할 수 있는 페이지를 보호
+const withAuth = (Component) => {
+  const WrappedComponent = (props) => {
+    const { pathname } = useLocation();
+    const token = localStorage.getItem('token');
+
+    if (token && (pathname === '/signup' || pathname === '/signin')) {
+      return <Navigate to="/todo" replace />;
+    } else if (!token && !(pathname === '/signup' || pathname === '/signin')) {
+      return <Navigate to="/signin" replace />;
+    }
+
+    return <Component {...props} />;
+  };
+
+  return WrappedComponent;
+};
+
+export default withAuth;


### PR DESCRIPTION
### 이슈 항목
- [x] 라우터, 인증 토큰 및 리다이렉트
- [ ] 유효성 검사
- [ ] API 요청
- [ ] 상태 관리
- [ ] 성능 최적화


### 간략한 로직 설명
1. [route](https://github.com/wanted-intern-1/pre-onboarding-10th-1-1/blob/96387969e584bcdb28f73ac3f46ed7437d610299/src/App.js)단 각 페이지 컴포넌트에 [withAuth](https://github.com/wanted-intern-1/pre-onboarding-10th-1-1/blob/96387969e584bcdb28f73ac3f46ed7437d610299/src/hocs/withAuth.jsx) HOC를 적용하면
2. [withAuth](https://github.com/wanted-intern-1/pre-onboarding-10th-1-1/blob/96387969e584bcdb28f73ac3f46ed7437d610299/src/hocs/withAuth.jsx) 안에서 사용자의 토큰 정보와 현재 경로를 가져와 로그인한 사용자는 `/todo`로 리다이렉트시킵니다. 

### 개선이유
1. 모든 페이지에서 중복된 코드로 인증 처리
2. useEffect로 처리하면서 인증되지 않은 유저도 해당 컴포넌트에 접근

### 개선사항 및 변경사항
1. 모든 페이지에서 중복된 코드로 인증 처리 -> HOC로 컴포넌트화
2. useEffect로 처리하면서 인증되지 않은 유저도 해당 컴포넌트에 접근 -> 해당 컴포넌트 렌더링을 시키지 않고 Redirect

### 의문점 및 한계점
- [ ] HOC로 작업하게 되면 중복되는 컴포넌트가 매번 렌더링 되는 이슈가 존재할 수 있습니다.
-> 이 부분은 성능 체크가 필요하고 `memo`를 쓰는 것도 방법이 될 것 같습니다.

### 확인
- [x] reviewer 체크하였나요?


